### PR TITLE
Fixed problem with zero min lengths being ignored 

### DIFF
--- a/src/SelvinOrtiz/Utils/Flux/Flux.php
+++ b/src/SelvinOrtiz/Utils/Flux/Flux.php
@@ -181,11 +181,11 @@ class Flux
 	{
 		$lastSegmentKey = $this->getLastSegmentKey();
 
-		if ($min && $max && $min > $max)
+		if (!is_null($min) && !is_null($max) && $max > $min)
 		{
 			$lengthPattern = sprintf('{%d,%d}', (int) $min, (int) $max);
 		}
-		elseif ($min && !$max)
+		elseif (!is_null($min) && !$max)
 		{
 			$lengthPattern = sprintf('{%d}', (int) $min);
 		}
@@ -487,11 +487,11 @@ class Flux
 
 	public function letters($min = null, $max = null)
 	{
-		if ($min && $max)
+		if (!is_null($min) && !is_null($max))
 		{
 			return $this->raw(sprintf('([a-zA-Z]{%d,%d})', $min, $max));
 		}
-		elseif ($min && is_null($max))
+		elseif (!is_null($min) && is_null($max))
 		{
 			return $this->raw(sprintf('([a-zA-Z]{%d})', $min));
 		}
@@ -503,11 +503,11 @@ class Flux
 
 	public function digits($min = null, $max = null)
 	{
-		if ($min && $max)
+		if (!is_null($min) && !is_null($max))
 		{
 			return $this->raw(sprintf('(\\d{%d,%d})', $min, $max));
 		}
-		elseif ($min && is_null($max))
+		elseif (!is_null($min) && is_null($max))
 		{
 			return $this->raw(sprintf('(\\d{%d})', $min));
 		}

--- a/tests/FluxTest.php
+++ b/tests/FluxTest.php
@@ -136,6 +136,7 @@ class FluxTest extends PHPUnit_Framework_TestCase
 	public function testLength()
 	{
 		$this->assertTrue( (string) Flux::getInstance()->word()->length(1) === '/(\w{1})/' );
+		$this->assertTrue( (string) Flux::getInstance()->word()->length(0,1) === '/(\w{0,1})/' );
 		$this->assertTrue( (string) Flux::getInstance()->then('hello')->length(5) === '/(hello{5})/' );
 	}
 


### PR DESCRIPTION
when $min was zero the code was assuming it hadn't been passed so it was impossible to have ranges "0-n" as they just became "n".

Also added a test to validate it